### PR TITLE
Update expose command for kubectl cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,7 @@ kubectl get pods
 Expose the app to the web by setting the port. Run the command:
 
 ```
-$ kubectl expose deployment/deploy-react-kubernetes-deployment 
-—-type=NodePort —-name=deploy-react-kubernetes-service —-port=3000
+$ kubectl expose deployment/deploy-react-kubernetes-deployment —-port=3000 —-type=NodePort
 ```
 
 * To access your application. You would need the public IP address of your cluster and NodePort of the service.


### PR DESCRIPTION
At least in Kubectl version v1.11.1, the format for exposing a Kubernetes application is: 

Usage:
  kubectl expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP] [--target-port=number-or-name]
[--name=name] [--external-ip=external-ip-of-service] [--type=type] [options]

The "--port=3000" flag should come before "--type=NodePort" otherwise it isn't recognised. Similarly, the "--name" flag names the service which will be the same as the deployment's name by default anyway. Having it there for me for some reason threw an error: 

Error from server (NotFound): deployments.extensions "—-name=deploy-react-kubernetes-service" not found.

I just removed it and it worked.